### PR TITLE
Add request body to delete-rest-client-action-body

### DIFF
--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -126,10 +126,11 @@ module.exports.RestClient = function (options) {
     return apiCall(request_data, request_token);
   }
 
-  instance.delete = function (resourceUrl, request_token = '') {
+  instance.delete = function (resourceUrl, data, request_token = '') {
     const request_data = {
       url: createUrl(resourceUrl),
-      method: 'DELETE'
+      method: 'DELETE',
+      body: data
     };
     return apiCall(request_data, request_token);
   }


### PR DESCRIPTION
The request body data of an delete request should be transported to the further request.

For example:
I have a REST endpoint in my Magento1 installation for the native newsletter implementation.
VSF `NewsletterService` class sends the email in the body as JSON-String. Now I can just change the newsletter endpoint in the VSF and the `NewsletterService` class sends a DELETE request to the API containing the body – BUT the API doesn't put it through (including the body-json-data) to the Magento bridge because it is missing in the `rest_client.js` class of the `magento1-vsbridge-client`.