### PR TITLE
Remove logger.info

### DIFF
--- a/lib/rest_client.js
+++ b/lib/rest_client.js
@@ -22,14 +22,6 @@ module.exports.RestClient = function (options) {
 
   function apiCall(request_data, request_token = '') {
     logger.debug('Calling API endpoint: ' + request_data.method + ' ' + request_data.url + ' token: ' + request_token);
-
-    logger.info({
-      url: request_data.url,
-      method: request_data.method,
-      headers: request_token ? { 'Authorization': 'Bearer ' + request_token } : oauth.toHeader(oauth.authorize(request_data, token)),
-      json: true,
-      body: request_data.body,
-    });
     /* eslint no-undef: off*/
     return new Promise(function (resolve, reject) {
       request({


### PR DESCRIPTION
Logging request_data.body logs raw password with login API.

This line is not really useful anyway and does not exists in magento2-vsbridge-client.